### PR TITLE
adapt to new dependency name from deps_target_dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,10 @@
 find_package(deps_target_dependency REQUIRED)
+
 rock_library(deps_target
     SOURCES Dummy.cpp
     HEADERS Dummy.hpp
-    DEPS_TARGET deps_target_dependency
+    DEPS_TARGET deps_target_dependency::deps_target_dependency
 )
 
 rock_executable(deps_target_bin Main.cpp
     DEPS deps_target)
-


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/build_tests-cmake-deps_target_dependency/pull/2

The dependency was renamed to ensure that there was no possible
confusion (and therefore "works by chance") between the library
name and the export name.